### PR TITLE
Implement From<&str>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,12 @@ impl fmt::Display for SmolStr {
     }
 }
 
+impl<'a> From<&'a str> for SmolStr {
+    fn from(text: &'a str) -> Self {
+        Self::new(text)
+    }
+}
+
 const INLINE_CAP: usize = 22;
 const WS_TAG: u8 = (INLINE_CAP + 1) as u8;
 const N_NEWLINES: usize = 32;


### PR DESCRIPTION
For simple usages, this makes it easier to fallback to `type SmolStr = String` if this is an optional dependency :)