### PR TITLE
clippy: Add (and test) is_empty method.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,11 @@ impl SmolStr {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl Deref for SmolStr {
@@ -177,6 +182,15 @@ impl Repr {
             Repr::Heap(data) => data.len(),
             Repr::Inline { len, .. } => *len as usize,
             Repr::Substring { newlines, spaces } => *newlines + *spaces,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Repr::Heap(data) => data.is_empty(),
+            Repr::Inline { len, .. } => *len == 0,
+            // A substring isn't created for an empty string.
+            Repr::Substring { .. } => false,
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -24,6 +24,7 @@ fn check_props(s: &str) -> Result<(), proptest::test_runner::TestCaseError> {
     let smol = SmolStr::new(s);
     prop_assert_eq!(smol.as_str(), s);
     prop_assert_eq!(smol.len(), s.len());
+    prop_assert_eq!(smol.is_empty(), s.is_empty());
     Ok(())
 }
 


### PR DESCRIPTION
Since there is a `len` method, clippy suggests having an `is_empty`
method as well.