### PR TITLE
implement Borrow<str> to make possible search str in HashMap<SmolStr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fmt, hash, ops::Deref, sync::Arc};
+use std::{borrow::Borrow, fmt, hash, ops::Deref, sync::Arc};
 
 /// A `SmolStr` is a string type that has the following properties:
 ///
@@ -145,6 +145,12 @@ where
 impl From<SmolStr> for String {
     fn from(text: SmolStr) -> Self {
         text.to_string()
+    }
+}
+
+impl Borrow<str> for SmolStr {
+    fn borrow(&self) -> &str {
+        self.as_str()
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -66,3 +66,10 @@ fn test_serde() {
     let s: SmolStr = serde_json::from_str(&s).unwrap();
     assert_eq!(s, "Hello, World");
 }
+
+#[test]
+fn test_search_in_hashmap() {
+    let mut m = ::std::collections::HashMap::<SmolStr, i32>::new();
+    m.insert("aaa".into(), 17);
+    assert_eq!(17, *m.get("aaa").unwrap());
+}


### PR DESCRIPTION
For `HashMap<String, T>` it is possible to call `HashMap::get(&str)`,
it would be convenient if the same will be possible for `SmolStr` 